### PR TITLE
improvement of follow function

### DIFF
--- a/instagram.js
+++ b/instagram.js
@@ -265,7 +265,7 @@ module.exports = class Instagram
     return fetch('https://www.instagram.com/web/friendships/'+userId+(isUnfollow == 1 ? '/unfollow' : '/follow'),
     {
       'method' : 'post',
-      'headers' : headers
+      'headers': this.getHeaders()//headers
     }).then(res =>
     {
       return res


### PR DESCRIPTION
File: Instagram.js
Method: Follow()

Change headers in fetch from built-in to this.getHeaders().

Line 268:
'headers': headers
change to
'headers': this.getHeaders()//headers

This change help me to repair this method. It's work fine now.