### PR TITLE
Ensure undefined cookies are not passed as literal

### DIFF
--- a/instagram.js
+++ b/instagram.js
@@ -52,7 +52,9 @@ module.exports = class Instagram {
     var keys = Object.keys(this.essentialValues)
     for (var i = 0; i < keys.length; i++){
       var key = keys[i];
-      cookie += key + '=' + this.essentialValues[key] + (i < keys.length - 1 ? '; ' : '')
+      if (this.essentialValues[key] !== undefined) {
+        cookie += key + '=' + this.essentialValues[key] + (i < keys.length - 1 ? '; ' : '')
+      }
     }
 
     return cookie;


### PR DESCRIPTION
For some logins the shbts/shbid cookies are not set, however when trying to do extra requests these parameters being undefined is causing a bad request to be sent to facebook. This change makes building the cookies more defensive.